### PR TITLE
Fix build on a clean machine (lv_conf.h assembly guard + touch.h inline)

### DIFF
--- a/firmware/claude_stick/lv_conf.h
+++ b/firmware/claude_stick/lv_conf.h
@@ -11,7 +11,13 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
+/* Guarda obrigatória: lv_conf_internal.h inclui este arquivo também durante a
+   montagem dos .S do LVGL (ex.: draw/sw/blend/helium/lv_blend_helium.S). Sem a
+   guarda, o assembler recebe os typedef de stdint.h e falha com
+   "unknown opcode or format name 'typedef'". Ver o aviso no lv_conf_internal.h. */
+#ifndef __ASSEMBLY__
 #include <stdint.h>
+#endif
 
 /*====================
    COLOR

--- a/firmware/claude_stick/touch.h
+++ b/firmware/claude_stick/touch.h
@@ -70,6 +70,11 @@ private:
     }
 };
 
-AXS15231B_Touch *AXS15231B_Touch::_instance = nullptr;
+// `inline` obrigatorio: isto e uma DEFINICAO em escopo de arquivo dentro de um
+// header. Enquanto o projeto era um .ino unico, so havia uma unidade de traducao
+// e passava despercebido. Com o codigo dividido em varios .cpp, o segundo include
+// gera "multiple definition of AXS15231B_Touch::_instance" — erro de LINKAGEM,
+// que aparece no fim do build e aponta para o header, nao para quem incluiu.
+inline AXS15231B_Touch *AXS15231B_Touch::_instance = nullptr;
 
 #endif // TOUCH_H


### PR DESCRIPTION
Two one-line fixes that are needed to build the firmware on a machine other than the author's. Both are latent bugs that only surface outside the original setup — the code is correct as long as there is exactly one translation unit and `lv_conf.h` happens to already be resolvable.

Verified on macOS with `arduino-cli` 1.5.1, `esp32:esp32@3.3.8`, `GFX Library for Arduino@1.6.5`, `lvgl@9.2.2`, on real hardware (ESP32-S3R8, 8MB octal PSRAM, 16MB flash). Firmware builds and runs: 2001038 bytes, 51% global RAM.

### 1. `lv_conf.h` — unguarded `#include <stdint.h>`

Clean build fails with:

```
lvgl/src/draw/sw/blend/helium/lv_blend_helium.S:10
xtensa-esp-elf/include/stdint.h:39: Error: unknown opcode or format name 'typedef'
```

`lv_conf_internal.h` includes `lv_conf.h` **unconditionally**, including while assembling LVGL's `.S` files, so the preprocessor feeds C typedefs to the assembler.

Worth noting: **neither workaround in the README avoids this**. Both `-DLV_CONF_INCLUDE_SIMPLE` and copying `lv_conf.h` next to the `lvgl` folder only change *where* the file is found, not *whether* it is included during assembly. I tested both before finding the actual cause.

The fix is what `lv_conf_internal.h` itself asks for a few lines above the failure point — *"If you need to include anything here, do it inside the `__ASSEMBLY__` guard"*.

### 2. `touch.h` — static member defined in a header

`AXS15231B_Touch *AXS15231B_Touch::_instance = nullptr;` at file scope in the header is a definition, not a declaration. With the firmware as a single `.ino` there is only one translation unit, so it goes unnoticed. Any additional `.cpp` that includes the header produces:

```
ld: touch.h:73: multiple definition of 'AXS15231B_Touch::_instance'
```

Marking it `inline` (C++17, available in esp32 core 3.x) keeps the definition in the header while guaranteeing a single symbol.

This one doesn't affect the current tree — I hit it while splitting the sketch into modules — but it's a real constraint on the header, so it seemed worth fixing at the source.

### Not included here

`firmware/bringup/` can't be built with the project's FQBN: it has no `partitions.csv` of its own, but the FQBN uses `PartitionScheme=custom`, so the build fails with `cp: .../partitions/.csv: No such file or directory`. Building it with `PartitionScheme=huge_app` works. I left this out since the right fix depends on whether you'd rather add a `partitions.csv` to the folder or document the alternate FQBN.

Thanks for the project — the touch UI is lovely, and reading usage straight from the `anthropic-ratelimit-unified-*` headers is a genuinely clever idea.
