### PR TITLE
fix: guard lv_conf.h stdint include with __ASSEMBLY__

### DIFF
--- a/firmware/claude_stick/lv_conf.h
+++ b/firmware/claude_stick/lv_conf.h
@@ -11,7 +11,14 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
+/* A lvgl compila lv_blend_neon.S / lv_blend_helium.S (ARM) mesmo em outras
+   arquiteturas, e esses .S chegam aqui pela cadeia do lv_conf_internal.h.
+   Sem esta guarda o assembler recebe os typedef do stdint.h e falha com
+   "unknown opcode or format name 'typedef'". E a convencao do proprio
+   lv_conf_template.h da LVGL. */
+#ifndef __ASSEMBLY__
 #include <stdint.h>
+#endif
 
 /*====================
    COLOR


### PR DESCRIPTION
# What does this PR do?

Guards the `#include <stdint.h>` in `firmware/claude_stick/lv_conf.h` with `#ifndef __ASSEMBLY__`, so the build survives when `lv_conf.h` is reachable from lvgl's assembly sources.

## The problem

lvgl ships two assembly files — `src/draw/sw/blend/neon/lv_blend_neon.S` and `src/draw/sw/blend/helium/lv_blend_helium.S`. The Arduino build compiles **every** source file in a library, regardless of target architecture, so both get fed to the xtensa toolchain. They start with:

```c
#ifndef __ASSEMBLY__
#define __ASSEMBLY__
#endif

#include "lv_blend_neon.h"
```

which reaches `lv_conf.h` through the `lv_conf_internal.h` chain. With the include unguarded, the assembler receives C typedefs and the build dies with dozens of:

```
.../xtensa-esp-elf/include/stdint.h:21: Error: unknown opcode or format name 'typedef'
```

## Why it doesn't reproduce on macOS

`build.sh` passes `-DLV_CONF_INCLUDE_SIMPLE -I<sketch>` through `compiler.c.extra_flags` / `compiler.cpp.extra_flags`. The ESP32 core's `.S` recipe uses `compiler.S.extra_flags` instead:

```
recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.extra_flags} {compiler.S.flags} ...
```

So the sketch-local `lv_conf.h` was never visible to assembly, and lvgl silently fell back to its defaults there. The failure appears as soon as `lv_conf.h` is copied into the Arduino `libraries/` folder — which is exactly the fallback the README documents:

> If you get `lv_conf.h not found`, copy `firmware/claude_stick/lv_conf.h` into your Arduino libraries folder (one level above the `lvgl` folder).

On Windows that fallback is effectively mandatory: the `-I` flag breaks on paths containing spaces, which the default `Documents\Arduino` location and most user project paths have.

Guarding the include is what upstream's own `lv_conf_template.h` prescribes:

> If you need to include anything here, do it inside the `__ASSEMBLY__` guard

## 📸 Device photo

Not attached — this is a toolchain/build fix rather than a new board port, and the only screenshot I have on hand shows my local SSIDs. Happy to attach a dashboard photo if you'd like one for the record.

## ✅ Checklist

### All PRs

- [x] Tested on real hardware — board: **Guition JC4832W535** (ESP32-S3, AXS15231B)

Environment: Windows 11, `arduino-cli` 1.5.1, core `esp32:esp32@3.3.8`, `GFX Library for Arduino@1.6.5`, `lvgl@9.2.2`. Build fails without this change and succeeds with it; the board flashes, boots, completes onboarding and shows live usage.

### New board port

n/a — no new board.
