### PR TITLE
Fix clean-build failure: guard stdint.h include in lv_conf.h

### DIFF
--- a/firmware/claude_stick/lv_conf.h
+++ b/firmware/claude_stick/lv_conf.h
@@ -11,7 +11,12 @@
 #ifndef LV_CONF_H
 #define LV_CONF_H
 
+/* Guard necessário: este arquivo também entra no preprocessamento dos fontes
+ * assembly do LVGL (lv_blend_helium.S / lv_blend_neon.S) via -I do sketch;
+ * um include C sem guard injeta typedefs no input do assembler Xtensa. */
+#if !defined(__ASSEMBLY__) && !defined(__ASSEMBLER__)
 #include <stdint.h>
+#endif
 
 /*====================
    COLOR


### PR DESCRIPTION
## Problema

Build limpo (cache do arduino-cli vazio) falha ao compilar os arquivos assembly do LVGL (`lv_blend_helium.S` / `lv_blend_neon.S`):

```
xtensa-esp-elf/include/machine/_default_types.h:41: Error: unknown opcode or format name 'typedef'
```

## Causa

O core esp32 injeta `-I<pasta do sketch>` em todas as receitas de compilação, inclusive na dos `.S` (via `compiler.cpreprocessor.flags` no platform.txt). O `lv_conf_internal.h` do LVGL 9.2.2 usa `__has_include("lv_conf.h")`, então o nosso `lv_conf.h` acaba incluído também no preprocessamento dos arquivos assembly. Como ele tinha `#include <stdint.h>` sem guard, os typedefs do newlib caíam direto no input do assembler Xtensa.

O bug só aparece em build limpo: com cache, os `.S.o` antigos são reaproveitados e nunca recompilam. Por isso builds incrementais continuavam passando.

## Fix

Guard no include, seguindo a convenção que o próprio `lv_conf_internal.h` documenta ("If you need to include anything here, do it inside the `__ASSEMBLY__` guard"):

```c
#if !defined(__ASSEMBLY__) && !defined(__ASSEMBLER__)
#include <stdint.h>
#endif
```

Os dois `.S` do LVGL definem `__ASSEMBLY__` no topo, e o gcc define `__ASSEMBLER__` para `-x assembler-with-cpp`, então qualquer um dos dois caminhos cobre.

## Teste

Build limpo + flash numa JC3248W535C (arduino-cli 1.5.1, core esp32 3.3.8, GFX 1.6.5, LVGL 9.2.2). Confirmei também preprocessando o `lv_blend_helium.S` isolado com o `-I` do sketch: zero typedefs no output. Firmware rodando no hardware, setup de WiFi e token concluído.