### PR TITLE
docs: Claude Code SessionStart hook as alternative to cron for token_bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,45 @@ python3 tools/token_bridge.py --loop 120    # keep pushing every 2 min
 The device advertises itself via mDNS as **`claude-stick.local`** while the dashboard is open. If
 the row disappears, the data just went stale (> 15 min without a push).
 
+#### Keeping it running via a Claude Code hook (alternative to cron)
+
+If your main use of the bridge is with the **Claude Code CLI**, you don't need a system cron job:
+a `SessionStart` hook can launch it automatically whenever you open a terminal session, and only
+while you're actually working — no requests to the device the rest of the day for nothing.
+
+[`tools/claude-code-token-bridge-hook.sh`](tools/claude-code-token-bridge-hook.sh) is a ready-made
+helper that checks (via `pgrep`) whether the bridge is already running before starting it, so
+opening several terminal tabs/sessions never spawns duplicate loops. Wire it into
+`~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /absolute/path/to/claude-usage-stick-SVGL/tools/claude-code-token-bridge-hook.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For a multi-account setup, set `CLAUDE_STICK_BRIDGE_ACCOUNT` to the label configured on the device
+before Claude Code starts (e.g. in your shell profile), same idea as the `--account` flag above.
+
+> **Don't inline the `pgrep`/`nohup` logic directly in the hook's `command` string.** The wrapping
+> shell process's own argv then contains the search pattern (since it's part of the command text
+> itself), and `pgrep -f` can intermittently match that wrapper process instead of the real bridge
+> — silently skipping the actual start. Keeping the logic in a separate script file avoids this,
+> since the script's own invocation (`bash .../claude-code-token-bridge-hook.sh`) doesn't contain
+> the pattern being searched for.
+
 With multiple accounts, run one bridge per machine with `--account <label>` (the label configured
 on the gadget). `GET /window` reports which account is active; a push for another account gets a
 `409` and is simply skipped until that account becomes active again.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -247,6 +247,44 @@ python3 tools/token_bridge.py --loop 120    # continua enviando a cada 2 min
 O device se anuncia por mDNS como **`claude-stick.local`** enquanto o painel está aberto. Se a
 linha sumir, é porque o dado ficou velho (> 15 min sem envio).
 
+#### Mantendo rodando via hook do Claude Code (alternativa ao cron)
+
+Se o seu uso principal da ponte é com o **Claude Code CLI**, não precisa de um cron do sistema: um
+hook `SessionStart` pode iniciar ela sozinha toda vez que você abre uma sessão de terminal — e só
+enquanto você está de fato trabalhando, sem ficar batendo no device o dia todo à toa.
+
+O [`tools/claude-code-token-bridge-hook.sh`](tools/claude-code-token-bridge-hook.sh) é um helper
+pronto que verifica (via `pgrep`) se a ponte já está rodando antes de iniciar, então abrir várias
+abas/sessões de terminal nunca duplica o loop. Basta ligar ele no `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash /caminho/absoluto/para/claude-usage-stick-SVGL/tools/claude-code-token-bridge-hook.sh",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Para várias contas, defina `CLAUDE_STICK_BRIDGE_ACCOUNT` com o rótulo configurado no device antes
+do Claude Code iniciar (por exemplo no seu perfil do shell) — mesma ideia da flag `--account` acima.
+
+> **Não embuta a lógica do `pgrep`/`nohup` direto na string `command` do hook.** O processo que
+> executa o comando do hook carrega, no seu próprio argv, o texto de busca (já que ele faz parte
+> do próprio comando) — e o `pgrep -f` pode acabar encontrando a si mesmo intermitentemente em vez
+> do processo real da ponte, deixando de iniciá-la sem avisar nada. Manter a lógica num arquivo de
+> script separado evita isso, já que a invocação do script
+> (`bash .../claude-code-token-bridge-hook.sh`) não contém o padrão sendo buscado.
+
 Com várias contas, rode uma ponte por máquina com `--account <rótulo>` (o rótulo configurado no
 gadget). O `GET /window` informa qual conta está ativa; um envio para outra conta recebe `409` e é
 simplesmente ignorado até aquela conta voltar a ser a ativa.

--- a/tools/claude-code-token-bridge-hook.sh
+++ b/tools/claude-code-token-bridge-hook.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Helper for a Claude Code CLI `SessionStart` hook: starts token_bridge.py in
+# the background if it isn't already running. See README -> "Tokens per
+# session (optional bridge)" for how to wire this into ~/.claude/settings.json.
+#
+# Usage from ~/.claude/settings.json:
+#   {
+#     "hooks": {
+#       "SessionStart": [
+#         { "hooks": [
+#           { "type": "command",
+#             "command": "bash /absolute/path/to/claude-usage-stick-SVGL/tools/claude-code-token-bridge-hook.sh",
+#             "timeout": 15 }
+#         ] }
+#       ]
+#     }
+#   }
+#
+# Multi-account setups: set CLAUDE_STICK_BRIDGE_ACCOUNT to the account label
+# configured on the device before invoking this script (or copy/edit it per
+# machine), same as the --account flag documented for token_bridge.py itself.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$DIR/tools/token_bridge.py"
+LOG="${CLAUDE_STICK_BRIDGE_LOG:-$HOME/Library/Logs/claude-usage-stick-token-bridge.log}"
+
+ARGS=(--loop 120)
+if [ -n "${CLAUDE_STICK_BRIDGE_ACCOUNT:-}" ]; then
+  ARGS+=(--account "$CLAUDE_STICK_BRIDGE_ACCOUNT")
+fi
+
+if ! pgrep -f "$SCRIPT" >/dev/null; then
+  nohup python3 -u "$SCRIPT" "${ARGS[@]}" >> "$LOG" 2>&1 &
+fi


### PR DESCRIPTION
## Summary

- Documents an alternative to the cron job for keeping `token_bridge.py` running: a Claude Code CLI `SessionStart` hook that starts it automatically whenever a terminal session opens, and only while you're actually working.
- Adds `tools/claude-code-token-bridge-hook.sh`, a ready-made helper that dedupes via `pgrep` before starting (so opening multiple terminal tabs/sessions never spawns duplicate loops), with optional `CLAUDE_STICK_BRIDGE_ACCOUNT` support for multi-account setups.
- Documented in both `README.md` and `README.pt-BR.md`.

One non-obvious thing worth calling out in case it saves someone else time: I first tried inlining the `pgrep`/`nohup` check directly in the hook's `command` string. That's intermittently broken — the wrapping shell process that runs the hook command has the search pattern in its own argv (since it's embedded in the command text), so `pgrep -f` can match itself instead of the real bridge process and silently skip starting it. Moving the logic into a separate script file fixes it, since the script's own invocation (`bash .../claude-code-token-bridge-hook.sh`) doesn't contain the pattern being searched for. Left a note about this in both READMEs.

This is purely additive (new optional doc section + new opt-in script) — nothing existing changes behavior.

## Test plan

- [x] `bash -n tools/claude-code-token-bridge-hook.sh` — syntax check
- [x] Ran it with no bridge running: starts `token_bridge.py --loop 120` in the background, logs to `$CLAUDE_STICK_BRIDGE_LOG`
- [x] Ran it again while already running: no-op (dedup via `pgrep` works)
- [x] Verified on my own device (JC3248W535C-style board) that the "Now" screen token row keeps updating end-to-end through the hook